### PR TITLE
Fix `Content-Type`

### DIFF
--- a/server/server.test.ts
+++ b/server/server.test.ts
@@ -1,6 +1,5 @@
 import { assertEquals } from "$std/assert/assert_equals.ts";
 import { assertStringIncludes } from "$std/assert/assert_string_includes.ts";
-import { assertThrows } from "$std/assert/assert_throws.ts";
 import { join } from "$std/path/join.ts";
 import { respond } from "./server.ts";
 
@@ -65,13 +64,9 @@ Deno.test(
     await res.body?.cancel();
 
     assertEquals(res.status, 200);
-    assertThrows(() =>
-      assertStringIncludes(
-        res.headers.get("Content-Type") ?? "",
-        // Currently, the .pkg file isn't served with the correct content type.
-        // However, this isn't a big deal, so I'm ignoring the failure.
-        "application/octet-stream",
-      ),
+    assertStringIncludes(
+      res.headers.get("Content-Type") ?? "",
+      "application/octet-stream",
     );
   },
 );

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,19 +1,19 @@
 import { serveDir } from "$std/http/file_server.ts";
 
-function serve(): void {
-  Deno.serve(async (req: Request): Promise<Response> => await respond(req));
-}
-
-const headers = [
-  "Cross-Origin-Opener-Policy: same-origin",
-  "Cross-Origin-Embedder-Policy: require-corp",
-];
-
 export async function respond(req: Request, dir = "build"): Promise<Response> {
-  return await serveDir(req, {
+  const path = new URL(req.url).pathname;
+  const res = await serveDir(req, {
     fsRoot: dir,
-    headers: headers,
+    enableCors: true,
   });
+
+  res.headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  res.headers.set("Cross-Origin-Embedder-Policy", " require-corp");
+  if (path.endsWith(".pck")) {
+    res.headers.set("Content-Type", "application/octet-stream");
+  }
+
+  return res;
 }
 
-serve();
+Deno.serve(async (req: Request): Promise<Response> => await respond(req));


### PR DESCRIPTION
## Description

This PR makes the `.pck` file use the correct `Content-Type`.

_Closes: #38_

---

## Type of Change

- 🐛 Bug fix

## Checklist

> Before submitting the PR, please make sure you do the following

- [x] Read the Contributing Guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Fill out this template.
- [x] Log your hours.
- [x] Check that commits follow the Angular commit convention, more or less.
- [x] Ideally, include relevant tests that fail without this PR but pass with it (if applicable).

## Tested on

- macOS 14
