### PR TITLE
Limit Camera

### DIFF
--- a/game/levels/1.tscn
+++ b/game/levels/1.tscn
@@ -32,6 +32,12 @@ position = Vector2(574, 536)
 
 [node name="Camera" type="Camera2D" parent="Wizard"]
 zoom = Vector2(2, 2)
+limit_left = -180
+limit_top = -300
+limit_right = 2700
+limit_bottom = 730
+limit_smoothed = true
+editor_draw_limits = true
 
 [node name="Rock" parent="." instance=ExtResource("3_ay7so")]
 position = Vector2(851, 503)

--- a/game/levels/tutorial.tscn
+++ b/game/levels/tutorial.tscn
@@ -41,6 +41,12 @@ position = Vector2(566, 538)
 
 [node name="Camera" type="Camera2D" parent="Wizard"]
 zoom = Vector2(2, 2)
+limit_left = 0
+limit_top = -200
+limit_right = 3990
+limit_bottom = 1000
+limit_smoothed = true
+editor_draw_limits = true
 
 [node name="SecretLabel" type="Label" parent="."]
 z_index = -5


### PR DESCRIPTION
## Description

This PR prevents the user from leaving the scene.

_**Note:** this does not **yet** prevent the player from leaving the level, just the camera._

---

## Type of Change

- 🐛 Bug fix

## Checklist

- [x] Read the Contributing Guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Fill out this template.
- [ ] Log your hours.
- [x] Check that commits follow the Angular commit convention, more or less.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it (if applicable).

## Tested on

- macOS 14
